### PR TITLE
get rid of services `description`

### DIFF
--- a/cncdb/cncdb.go
+++ b/cncdb/cncdb.go
@@ -135,7 +135,7 @@ func (c *CNCMySQLHandler) GetRecordInfo(identifier string) (*DBData, error) {
 				"m.id, "+
 				"GREATEST(m.created, m.updated), "+
 				"m.type, "+
-				"COALESCE(m.desc_en, ms.description), "+
+				"m.desc_en, "+
 				"m.desc_cs, "+
 				"m.license_info, "+
 				"m.authors, "+
@@ -207,7 +207,7 @@ func (c *CNCMySQLHandler) ListRecordInfo(from *time.Time, until *time.Time) ([]D
 			"m.id, "+
 			" GREATEST(m.created, m.updated), "+
 			"m.type, "+
-			"COALESCE(m.desc_en, ms.description), "+
+			"m.desc_en, "+
 			"m.desc_cs, "+
 			"m.license_info, "+
 			"m.authors, "+

--- a/cncdb/scripts/schema.sql
+++ b/cncdb/scripts/schema.sql
@@ -8,7 +8,6 @@ CREATE TABLE vlo_metadata_corpus (
 CREATE TABLE vlo_metadata_service (
   id int(11) PRIMARY KEY NOT NULL AUTO_INCREMENT,
   name varchar(255) NOT NULL,
-  description varchar(255) NOT NULL,
   link varchar(255) NOT NULL,
   UNIQUE (name)
 ) ENGINE=InnoDB DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;


### PR DESCRIPTION
Since common metadata titles were repurposed as descriptions it is redundant now